### PR TITLE
Display agent ids and highlight mentions

### DIFF
--- a/src/components/AgentCard.tsx
+++ b/src/components/AgentCard.tsx
@@ -9,7 +9,8 @@ export default function AgentCard({ agent }: { agent: AgentType }) {
   const router = useRouter();
   return (
     <div className="p-4 rounded-2xl shadow-md border bg-white">
-      <h2 className="text-xl font-bold mb-2 text-gray-900">{agent.name}</h2>
+      <h2 className="text-xl font-bold mb-1 text-gray-900">{agent.name}</h2>
+      <p className="text-xs text-gray-500 mb-2">ID: {agent.id}</p>
       <p className="text-sm text-gray-700">{agent.purpose}</p>
       <button
         className="mt-4 bg-blue-600 text-white px-4 py-2 rounded"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,6 +56,17 @@ export default function HomePage() {
 
   const nameFor = (id: string) => (id === 'user' ? 'You' : agents.find(a => a.id === id)?.name || id)
 
+  const renderContent = (text: string) =>
+    text.split(/(@[\w-]+)/g).map((part, i) =>
+      part.startsWith('@') ? (
+        <span key={i}>
+          @<span className="text-blue-600">{part.slice(1)}</span>
+        </span>
+      ) : (
+        <span key={i}>{part}</span>
+      )
+    )
+
   return (
     <Layout>
       <div className="grid md:grid-cols-3 gap-6">
@@ -72,7 +83,7 @@ export default function HomePage() {
               {messages.map((m, idx) => (
                 <div key={idx} className="whitespace-pre-wrap">
                   <span className="font-bold mr-1">{nameFor(m.agentId)}:</span>
-                  {m.content}
+                  {renderContent(m.content)}
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- show agent id on each AgentCard
- highlight @mentions in chat messages with blue agent IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688b81ff99508331a5c6b7c9cda106a8