### PR TITLE
feat: show conversation files on logs page

### DIFF
--- a/src/pages/api/logs.ts
+++ b/src/pages/api/logs.ts
@@ -1,10 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { readLegacyConversations } from '@/lib/logConversation'
+import { readConversations, readLegacyConversations } from '@/lib/logConversation'
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).end()
   const logs = readLegacyConversations()
+  const conversations = readConversations()
 
-  res.status(200).json({ logs })
+  res.status(200).json({ logs, conversations })
 }

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -2,18 +2,16 @@ import { useEffect, useState } from 'react'
 
 export default function LogsPage() {
   const [logs, setLogs] = useState<any[]>([])
-
-
+  const [conversations, setConversations] = useState<Record<string, any[]>>({})
 
   useEffect(() => {
     fetch('/api/logs')
       .then(res => res.json())
-
       .then(data => {
         const entries = Array.isArray(data.logs) ? data.logs : []
         setLogs(entries)
+        setConversations(data.conversations || {})
       })
-
       .catch(() => {})
   }, [])
 
@@ -26,6 +24,19 @@ export default function LogsPage() {
             <div className="text-xs text-gray-500">{log.timestamp}</div>
             <div className="font-semibold whitespace-pre-wrap">Prompt: {log.prompt}</div>
             <div className="whitespace-pre-wrap">Response: {log.response}</div>
+          </li>
+        ))}
+      </ul>
+      <h2 className="text-xl font-bold mt-8 mb-4">Saved Conversations</h2>
+      <ul className="space-y-4">
+        {Object.entries(conversations).map(([id, messages]) => (
+          <li key={id} className="p-2 border rounded">
+            <div className="font-semibold mb-2">Conversation {id}</div>
+            {messages.map((msg: any, mIdx: number) => (
+              <div key={mIdx} className="whitespace-pre-wrap">
+                <span className="font-medium">{msg.role}:</span> {msg.content}
+              </div>
+            ))}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- include conversation JSON files in /api/logs response
- display saved conversation messages on the logs page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cbffc58548331bdcb5d601816afb0