### PR TITLE
feat: manage agents

### DIFF
--- a/data/agents.json
+++ b/data/agents.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "prompt_specialist",
+    "name": "Prompt Specialist",
+    "purpose": "Refines venture questions into sharp, testable prompts",
+    "inputType": "text",
+    "prompt": "You are the Prompt Specialist. Transform the venture idea below into a single clear question that can be used to test the concept."
+  },
+  {
+    "id": "ai_infuser",
+    "name": "AI Infuser",
+    "purpose": "Map how AI is applied across operations",
+    "inputType": "text",
+    "prompt": "You are the AI Infuser. Outline a blueprint showing how AI can augment every operational level including toolkits, workflows and community-facing services based on the description below."
+  },
+  {
+    "id": "market_signal_miner",
+    "name": "Market Signal Miner",
+    "purpose": "Surface weak signals and untapped demand",
+    "inputType": "text",
+    "prompt": "You are the Market Signal Miner. Using the information provided, list emerging opportunities and unmet needs in the region. Present an opportunity map."
+  },
+  {
+    "id": "spark_scanner",
+    "name": "Spark Scanner",
+    "purpose": "Identify viable go-to-market entry points",
+    "inputType": "text",
+    "prompt": "You are the Spark Scanner. For the sector described below, propose a sharp go-to-market wedge with example offerings."
+  },
+  {
+    "id": "geo_matcher",
+    "name": "Geo-Matcher",
+    "purpose": "Evaluate country-level viability",
+    "inputType": "text",
+    "prompt": "You are the Geo-Matcher. Assess the country's viability considering government traction, infrastructure, talent, capital and security. Provide a go/no-go decision and timing recommendation."
+  },
+  {
+    "id": "behavioral_economist",
+    "name": "Behavioral Economist",
+    "purpose": "Model local founder psychology and adoption",
+    "inputType": "text",
+    "prompt": "You are the Behavioral Economist. Based on the context below, create a trust-building onboarding plan and suggest any tool interface adjustments to increase adoption."
+  },
+  {
+    "id": "aig_deal_evaluator",
+    "name": "AIG Deal Evaluator",
+    "purpose": "Assess strategic model and exit options",
+    "inputType": "text",
+    "prompt": "You are a venture analyst. Given the business summary below..."
+  },
+  {
+    "id": "market_scope_analyst",
+    "name": "Market Scope Analyst",
+    "purpose": "Size the SOM, SAM and TAM for the opportunity",
+    "inputType": "text",
+    "prompt": "You are the Market Scope Analyst. Build a concise market sizing model starting with Burundi and expanding regionally based on the information below."
+  },
+  {
+    "id": "channel_choreographer",
+    "name": "Channel Choreographer",
+    "purpose": "Design acquisition and retention channels",
+    "inputType": "text",
+    "prompt": "You are the Channel Choreographer. Describe low-CAC onboarding tactics, partnership pathways and referral loops for the initiative described below."
+  },
+  {
+    "id": "risk_cartographer",
+    "name": "Risk Cartographer",
+    "purpose": "Map political, operational and reputational risks",
+    "inputType": "text",
+    "prompt": "You are the Risk Cartographer. Create a risk matrix for the scenario below and provide mitigation levers."
+  },
+  {
+    "id": "venture_forensics",
+    "name": "Venture Forensics",
+    "purpose": "Build the internal operations financial model",
+    "inputType": "text",
+    "prompt": "You are the Venture Forensics agent. Using the assumptions below, calculate cost per founder, breakeven on services and subsidy multipliers."
+  },
+  {
+    "id": "capital_architect",
+    "name": "Capital Architect",
+    "purpose": "Design the capital stack strategy",
+    "inputType": "text",
+    "prompt": "You are the Capital Architect. Recommend a blend of grants, PPPs, diaspora equity and other financing aligned with the risk profile described below."
+  },
+  {
+    "id": "exit_synthesizer",
+    "name": "Exit Synthesizer",
+    "purpose": "Outline potential exit routes",
+    "inputType": "text",
+    "prompt": "You are the Exit Synthesizer. Provide a framework of possible exits such as acqui-hire, licensing or government buyout with conditions and timelines."
+  },
+  {
+    "id": "narrative_shaper",
+    "name": "Narrative Shaper",
+    "purpose": "Craft the story that sells to stakeholders",
+    "inputType": "text",
+    "prompt": "You are the Narrative Shaper. Draft messaging and public framing that resonates with donors, governments and founders based on the outline below."
+  },
+  {
+    "id": "integrator",
+    "name": "Integrator",
+    "purpose": "Synthesize outputs from all agents",
+    "inputType": "text",
+    "prompt": "You are the Integrator. Considering the information below, return a green, yellow or red light for each initiative and describe the learning loop."
+  }
+]
+

--- a/src/components/AgentCard.tsx
+++ b/src/components/AgentCard.tsx
@@ -4,19 +4,42 @@
 import Link from "next/link";
 import type { AgentType } from "@/types/agent";
 
+type Props = {
+  agent: AgentType;
+  onEdit?: (agent: AgentType) => void;
+  onDelete?: (id: string) => void;
+};
 
-export default function AgentCard({ agent }: { agent: AgentType }) {
+export default function AgentCard({ agent, onEdit, onDelete }: Props) {
   return (
     <div className="p-4 rounded-2xl shadow-md border bg-white">
       <h2 className="text-xl font-bold mb-1 text-gray-900">{agent.name}</h2>
       <p className="text-xs text-gray-500 mb-2">ID: {agent.id}</p>
       <p className="text-sm text-gray-700">{agent.purpose}</p>
-      <Link
-        href={`/agent/${agent.id}`}
-        className="mt-4 bg-blue-600 text-white px-4 py-2 rounded inline-block text-center"
-      >
-        Run Agent
-      </Link>
+      <div className="mt-4 flex gap-2">
+        <Link
+          href={`/agent/${agent.id}`}
+          className="bg-blue-600 text-white px-4 py-2 rounded text-center"
+        >
+          Run Agent
+        </Link>
+        {onEdit && (
+          <button
+            className="bg-yellow-500 text-white px-3 py-2 rounded"
+            onClick={() => onEdit(agent)}
+          >
+            Edit
+          </button>
+        )}
+        {onDelete && (
+          <button
+            className="bg-red-600 text-white px-3 py-2 rounded"
+            onClick={() => onDelete(agent.id)}
+          >
+            Delete
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -1,110 +1,52 @@
+import fs from 'fs'
+import path from 'path'
+import type { AgentType } from '@/types/agent'
 
-import { AgentType } from "@/types/agent";
+const agentsFile = path.join(process.cwd(), 'data', 'agents.json')
 
-export const agents: AgentType[] = [
-  {
-    id: "prompt_specialist",
-    name: "Prompt Specialist",
-    purpose: "Refines venture questions into sharp, testable prompts",
-    inputType: "text",
-    prompt: `You are the Prompt Specialist. Transform the venture idea below into a single clear question that can be used to test the concept.`,
-  },
-  {
-    id: "ai_infuser",
-    name: "AI Infuser",
-    purpose: "Map how AI is applied across operations",
-    inputType: "text",
-    prompt: `You are the AI Infuser. Outline a blueprint showing how AI can augment every operational level including toolkits, workflows and community-facing services based on the description below.`,
-  },
-  {
-    id: "market_signal_miner",
-    name: "Market Signal Miner",
-    purpose: "Surface weak signals and untapped demand",
-    inputType: "text",
-    prompt: `You are the Market Signal Miner. Using the information provided, list emerging opportunities and unmet needs in the region. Present an opportunity map.`,
-  },
-  {
-    id: "spark_scanner",
-    name: "Spark Scanner",
-    purpose: "Identify viable go-to-market entry points",
-    inputType: "text",
-    prompt: `You are the Spark Scanner. For the sector described below, propose a sharp go-to-market wedge with example offerings.`,
-  },
-  {
-    id: "geo_matcher",
-    name: "Geo-Matcher",
-    purpose: "Evaluate country-level viability",
-    inputType: "text",
-    prompt: `You are the Geo-Matcher. Assess the country's viability considering government traction, infrastructure, talent, capital and security. Provide a go/no-go decision and timing recommendation.`,
-  },
-  {
-    id: "behavioral_economist",
-    name: "Behavioral Economist",
-    purpose: "Model local founder psychology and adoption",
-    inputType: "text",
-    prompt: `You are the Behavioral Economist. Based on the context below, create a trust-building onboarding plan and suggest any tool interface adjustments to increase adoption.`,
-  },
-  {
-    id: "aig_deal_evaluator",
-    name: "AIG Deal Evaluator",
-    purpose: "Assess strategic model and exit options",
-    inputType: "text",
-    prompt: `You are a venture analyst. Given the business summary below...`,
-  },
-  {
-    id: "market_scope_analyst",
-    name: "Market Scope Analyst",
-    purpose: "Size the SOM, SAM and TAM for the opportunity",
-    inputType: "text",
-    prompt: `You are the Market Scope Analyst. Build a concise market sizing model starting with Burundi and expanding regionally based on the information below.`,
-  },
-  {
-    id: "channel_choreographer",
-    name: "Channel Choreographer",
-    purpose: "Design acquisition and retention channels",
-    inputType: "text",
-    prompt: `You are the Channel Choreographer. Describe low-CAC onboarding tactics, partnership pathways and referral loops for the initiative described below.`,
-  },
-  {
-    id: "risk_cartographer",
-    name: "Risk Cartographer",
-    purpose: "Map political, operational and reputational risks",
-    inputType: "text",
-    prompt: `You are the Risk Cartographer. Create a risk matrix for the scenario below and provide mitigation levers.`,
-  },
-  {
-    id: "venture_forensics",
-    name: "Venture Forensics",
-    purpose: "Build the internal operations financial model",
-    inputType: "text",
-    prompt: `You are the Venture Forensics agent. Using the assumptions below, calculate cost per founder, breakeven on services and subsidy multipliers.`,
-  },
-  {
-    id: "capital_architect",
-    name: "Capital Architect",
-    purpose: "Design the capital stack strategy",
-    inputType: "text",
-    prompt: `You are the Capital Architect. Recommend a blend of grants, PPPs, diaspora equity and other financing aligned with the risk profile described below.`,
-  },
-  {
-    id: "exit_synthesizer",
-    name: "Exit Synthesizer",
-    purpose: "Outline potential exit routes",
-    inputType: "text",
-    prompt: `You are the Exit Synthesizer. Provide a framework of possible exits such as acqui-hire, licensing or government buyout with conditions and timelines.`,
-  },
-  {
-    id: "narrative_shaper",
-    name: "Narrative Shaper",
-    purpose: "Craft the story that sells to stakeholders",
-    inputType: "text",
-    prompt: `You are the Narrative Shaper. Draft messaging and public framing that resonates with donors, governments and founders based on the outline below.`,
-  },
-  {
-    id: "integrator",
-    name: "Integrator",
-    purpose: "Synthesize outputs from all agents",
-    inputType: "text",
-    prompt: `You are the Integrator. Considering the information below, return a green, yellow or red light for each initiative and describe the learning loop.`,
-  },
-];
+function readAgents(): AgentType[] {
+  try {
+    const data = fs.readFileSync(agentsFile, 'utf8')
+    return JSON.parse(data) as AgentType[]
+  } catch {
+    return []
+  }
+}
+
+function writeAgents(agents: AgentType[]) {
+  fs.mkdirSync(path.dirname(agentsFile), { recursive: true })
+  fs.writeFileSync(agentsFile, JSON.stringify(agents, null, 2))
+}
+
+export function getAgents() {
+  return readAgents()
+}
+
+export function getAgent(id: string) {
+  return readAgents().find(a => a.id === id)
+}
+
+export function addAgent(agent: AgentType) {
+  const agents = readAgents()
+  if (agents.some(a => a.id === agent.id)) {
+    throw new Error('Agent already exists')
+  }
+  agents.push(agent)
+  writeAgents(agents)
+}
+
+export function updateAgent(id: string, data: Partial<AgentType>) {
+  const agents = readAgents()
+  const idx = agents.findIndex(a => a.id === id)
+  if (idx === -1) {
+    throw new Error('Agent not found')
+  }
+  agents[idx] = { ...agents[idx], ...data }
+  writeAgents(agents)
+}
+
+export function deleteAgent(id: string) {
+  const agents = readAgents().filter(a => a.id !== id)
+  writeAgents(agents)
+}
+

--- a/src/pages/agent/[id].tsx
+++ b/src/pages/agent/[id].tsx
@@ -1,13 +1,23 @@
 
 import { useRouter } from 'next/router';
-import { agents } from "@/lib/agents";
+import { useEffect, useState } from 'react';
 import AgentModal from "@/components/AgentModal";
 import Layout from "@/components/Layout";
+import type { AgentType } from "@/types/agent";
 
 export default function AgentPage() {
   const router = useRouter();
   const { id } = router.query;
-  const agent = agents.find(a => a.id === id);
+  const [agent, setAgent] = useState<AgentType | null>(null);
+
+  useEffect(() => {
+    if (typeof id === 'string') {
+      fetch(`/api/agents/${id}`)
+        .then(res => res.json())
+        .then(setAgent)
+        .catch(() => setAgent(null));
+    }
+  }, [id]);
 
   if (!agent) return <Layout>Agent not found.</Layout>;
 

--- a/src/pages/api/agents/[id].ts
+++ b/src/pages/api/agents/[id].ts
@@ -1,0 +1,29 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getAgent, updateAgent, deleteAgent } from '@/lib/agents'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query
+  if (typeof id !== 'string') return res.status(400).end()
+
+  if (req.method === 'GET') {
+    const agent = getAgent(id)
+    return agent ? res.status(200).json(agent) : res.status(404).end()
+  }
+
+  if (req.method === 'PUT') {
+    try {
+      updateAgent(id, req.body)
+      return res.status(200).json({ ok: true })
+    } catch (err: any) {
+      return res.status(400).json({ error: err.message })
+    }
+  }
+
+  if (req.method === 'DELETE') {
+    deleteAgent(id)
+    return res.status(200).json({ ok: true })
+  }
+
+  res.status(405).end()
+}
+

--- a/src/pages/api/agents/index.ts
+++ b/src/pages/api/agents/index.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getAgents, addAgent } from '@/lib/agents'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    return res.status(200).json(getAgents())
+  }
+
+  if (req.method === 'POST') {
+    try {
+      addAgent(req.body)
+      return res.status(201).json({ ok: true })
+    } catch (err: any) {
+      return res.status(400).json({ error: err.message })
+    }
+  }
+
+  res.status(405).end()
+}
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
 
 import { useEffect, useRef, useState } from "react"
 import Layout from "@/components/Layout"
-import { agents } from "@/lib/agents"
 import { chatCompletion } from "@/lib/openaiClient"
 import type { ChatMessage } from "@/types/chat"
+import type { AgentType } from "@/types/agent"
 import AgentCard from "@/components/AgentCard"
 
 export default function HomePage() {
@@ -13,12 +13,20 @@ export default function HomePage() {
     const saved = sessionStorage.getItem('chat')
     return saved ? JSON.parse(saved) : []
   })
+  const [agents, setAgents] = useState<AgentType[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     sessionStorage.setItem('chat', JSON.stringify(messages))
     containerRef.current?.scrollTo(0, containerRef.current.scrollHeight)
   }, [messages])
+
+  useEffect(() => {
+    fetch('/api/agents')
+      .then(res => res.json())
+      .then(setAgents)
+      .catch(() => setAgents([]))
+  }, [])
 
   const extractMentions = (text: string) => {
     const ids = Array.from(new Set(text.match(/@([\w-]+)/g)?.map(m => m.slice(1)) || []))
@@ -54,6 +62,41 @@ export default function HomePage() {
     }
   }
 
+  const addAgent = async () => {
+    const id = prompt('Agent ID?')?.trim()
+    if (!id) return
+    const name = prompt('Name?', id) || id
+    const purpose = prompt('Purpose?') || ''
+    const promptText = prompt('Prompt?') || ''
+    const newAgent: AgentType = { id, name, purpose, inputType: 'text', prompt: promptText }
+    await fetch('/api/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newAgent),
+    })
+    setAgents(prev => [...prev, newAgent])
+  }
+
+  const editAgent = async (agent: AgentType) => {
+    const name = prompt('Name?', agent.name)
+    if (!name) return
+    const purpose = prompt('Purpose?', agent.purpose) || ''
+    const promptText = prompt('Prompt?', agent.prompt) || ''
+    const updated: AgentType = { ...agent, name, purpose, prompt: promptText }
+    await fetch(`/api/agents/${agent.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updated),
+    })
+    setAgents(prev => prev.map(a => (a.id === agent.id ? updated : a)))
+  }
+
+  const deleteAgent = async (id: string) => {
+    if (!confirm('Delete agent?')) return
+    await fetch(`/api/agents/${id}`, { method: 'DELETE' })
+    setAgents(prev => prev.filter(a => a.id !== id))
+  }
+
   const saveConversation = async () => {
     if (messages.length === 0) return
     const conversationId = crypto.randomUUID()
@@ -85,9 +128,20 @@ export default function HomePage() {
     <Layout>
       <div className="grid md:grid-cols-3 gap-6">
         <div className="md:col-span-2 space-y-4">
+          <button
+            className="bg-blue-500 text-white px-4 py-2 rounded"
+            onClick={addAgent}
+          >
+            Add Agent
+          </button>
           <div className="grid sm:grid-cols-2 gap-4">
             {agents.map(agent => (
-              <AgentCard key={agent.id} agent={agent} />
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                onEdit={editAgent}
+                onDelete={deleteAgent}
+              />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add file-backed CRUD utilities for agents
- expose API routes to manage agent list
- add UI controls to create, update, and remove agents

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e5f6969a88331baedcdc3d8e5dfcc