### PR TITLE
feat: improve chat input and controls

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,10 @@ export default function HomePage() {
     const saved = sessionStorage.getItem('chat')
     return saved ? JSON.parse(saved) : []
   })
+  const [defaultAgentId, setDefaultAgentId] = useState(() => {
+    if (typeof window === 'undefined') return 'prompt_specialist'
+    return sessionStorage.getItem('defaultAgentId') || 'prompt_specialist'
+  })
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -20,9 +24,14 @@ export default function HomePage() {
     containerRef.current?.scrollTo(0, containerRef.current.scrollHeight)
   }, [messages])
 
-  const extractMentions = (text: string) => {
-    const ids = Array.from(new Set(text.match(/@([\w-]+)/g)?.map(m => m.slice(1)) || []))
-    return agents.filter(a => ids.includes(a.id))
+  useEffect(() => {
+    sessionStorage.setItem('defaultAgentId', defaultAgentId)
+  }, [defaultAgentId])
+
+  const extractLastMention = (text: string) => {
+    const ids = text.match(/@([\w-]+)/g)?.map(m => m.slice(1)) || []
+    const lastId = ids[ids.length - 1]
+    return agents.find(a => a.id === lastId) || null
   }
 
   const sendMessage = async () => {
@@ -34,23 +43,26 @@ export default function HomePage() {
       timestamp: Date.now(),
     }
     setMessages(prev => [...prev, userMsg])
-    const targets = extractMentions(input)
+    const mentioned = extractLastMention(input)
+    const target = mentioned || agents.find(a => a.id === defaultAgentId)!
     setInput('')
 
-    for (const agent of targets) {
-      const history = [...messages, userMsg].map(m => ({
-        role: m.role === 'user' ? 'user' : 'assistant',
-        content: m.content,
-      }))
-      const system = { role: 'system', content: agent.prompt }
-      const result = await chatCompletion([system, ...history])
-      const agentMsg: ChatMessage = {
-        role: 'agent',
-        agentId: agent.id,
-        content: result,
-        timestamp: Date.now(),
-      }
-      setMessages(prev => [...prev, agentMsg])
+    const history = [...messages, userMsg].map(m => ({
+      role: m.role === 'user' ? 'user' : 'assistant',
+      content: m.content,
+    }))
+    const system = { role: 'system', content: target.prompt }
+    const result = await chatCompletion([system, ...history])
+    const agentMsg: ChatMessage = {
+      role: 'agent',
+      agentId: target.id,
+      content: result,
+      timestamp: Date.now(),
+    }
+    setMessages(prev => [...prev, agentMsg])
+
+    if (mentioned) {
+      setDefaultAgentId(mentioned.id)
     }
   }
 
@@ -65,6 +77,15 @@ export default function HomePage() {
       })
     } catch {
       // ignore
+    }
+  }
+
+  const deleteConversation = () => {
+    setMessages([])
+    setDefaultAgentId('prompt_specialist')
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem('chat')
+      sessionStorage.removeItem('defaultAgentId')
     }
   }
 
@@ -93,6 +114,9 @@ export default function HomePage() {
         </div>
         <div className="md:col-span-1">
           <div className="flex flex-col h-[70vh] border rounded p-4">
+            <div className="text-sm text-gray-500 mb-2">
+              Default agent: {nameFor(defaultAgentId)}
+            </div>
             <div className="flex-1 overflow-y-auto space-y-2" ref={containerRef}>
               {messages.map((m, idx) => (
                 <div key={idx} className="whitespace-pre-wrap">
@@ -101,18 +125,32 @@ export default function HomePage() {
                 </div>
               ))}
             </div>
-            <div className="mt-4 flex gap-2">
-              <input
-                className="flex-1 border rounded p-2"
+            <div className="mt-4 flex gap-2 items-end">
+              <textarea
+                className="flex-1 border rounded p-2 resize-none overflow-hidden"
                 value={input}
+                rows={1}
                 onChange={e => setInput(e.target.value)}
+                onInput={e => {
+                  e.currentTarget.style.height = 'auto'
+                  e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault()
+                    void sendMessage()
+                  }
+                }}
                 placeholder="Type a message. Mention agents with @agentId"
               />
-              <button className="bg-blue-600 text-white px-4 rounded" onClick={sendMessage}>
+              <button className="bg-blue-600 text-white px-4 rounded h-full" onClick={sendMessage}>
                 Send
               </button>
-              <button className="bg-green-600 text-white px-4 rounded" onClick={saveConversation}>
+              <button className="bg-green-600 text-white px-4 rounded h-full" onClick={saveConversation}>
                 Save
+              </button>
+              <button className="bg-red-600 text-white px-4 rounded h-full" onClick={deleteConversation}>
+                Delete
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- use auto-resizing textarea for chat input and send on Enter
- add delete conversation control to clear saved messages
- default to the Prompt Specialist agent and update default when another agent is mentioned
- route each message to a single active agent, using the last @mention when present

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e604d89bc83318fd5bf346ddc6a75