### PR TITLE
feat: add chat save delete notifications and thinking indicator

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,9 @@ export default function HomePage() {
     return saved ? JSON.parse(saved) : []
   })
 
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [thinking, setThinking] = useState(false)
+
   const [defaultAgentId, setDefaultAgentId] = useState(() => {
     if (typeof window === 'undefined') return 'prompt_specialist'
     return sessionStorage.getItem('defaultAgentId') || 'prompt_specialist'
@@ -36,6 +39,11 @@ export default function HomePage() {
   useEffect(() => {
     sessionStorage.setItem('defaultAgentId', defaultAgentId)
   }, [defaultAgentId])
+
+  const showStatus = (msg: string) => {
+    setStatusMessage(msg)
+    setTimeout(() => setStatusMessage(null), 2000)
+  }
 
 
   const extractLastMention = (text: string) => {
@@ -61,25 +69,28 @@ export default function HomePage() {
 
     setInput('')
 
-    const history = [...messages, userMsg].map(m => ({
-      role: m.role === 'user' ? 'user' : 'assistant',
-      content: m.content,
-    }))
-    const system = { role: 'system', content: target.prompt }
-    const result = await chatCompletion([system, ...history])
-    const agentMsg: ChatMessage = {
-      role: 'agent',
-      agentId: target.id,
-      content: result,
-      timestamp: Date.now(),
+    setThinking(true)
+    try {
+      const history = [...messages, userMsg].map(m => ({
+        role: m.role === 'user' ? 'user' : 'assistant',
+        content: m.content,
+      }))
+      const system = { role: 'system', content: target.prompt }
+      const result = await chatCompletion([system, ...history])
+      const agentMsg: ChatMessage = {
+        role: 'agent',
+        agentId: target.id,
+        content: result,
+        timestamp: Date.now(),
+      }
+      setMessages(prev => [...prev, agentMsg])
+
+      if (mentioned) {
+        setDefaultAgentId(mentioned.id)
+      }
+    } finally {
+      setThinking(false)
     }
-    setMessages(prev => [...prev, agentMsg])
-
-    if (mentioned) {
-      setDefaultAgentId(mentioned.id)
-    }
-
-
   }
 
   const addAgent = async () => {
@@ -123,6 +134,7 @@ export default function HomePage() {
     } catch {
       // ignore
     }
+    showStatus('saved')
   }
 
   const deleteConversation = () => {
@@ -132,6 +144,7 @@ export default function HomePage() {
       sessionStorage.removeItem('chat')
       sessionStorage.removeItem('defaultAgentId')
     }
+    showStatus('deleted')
   }
 
   const nameFor = (id: string) => (id === 'user' ? 'You' : agents.find(a => a.id === id)?.name || id)
@@ -149,6 +162,11 @@ export default function HomePage() {
 
   return (
     <Layout>
+      {(statusMessage || thinking) && (
+        <div className="fixed top-4 right-4 bg-gray-800 text-white px-3 py-1 rounded shadow">
+          {statusMessage || 'thinking'}
+        </div>
+      )}
       <div className="grid md:grid-cols-3 gap-6">
         <div className="md:col-span-2 space-y-4">
           <button


### PR DESCRIPTION
## Summary
- show temporary "saved" popup after saving a chat
- show temporary "deleted" popup after deleting a chat
- display a "thinking" indicator while awaiting an agent response

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f521d7a24833184622d2d4bf62cb6