### PR TITLE
feat: add conversation resume

### DIFF
--- a/src/pages/api/log/[id].ts
+++ b/src/pages/api/log/[id].ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { readConversation } from '@/lib/logConversation'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') return res.status(405).end()
+  const { id } = req.query
+  if (typeof id !== 'string') {
+    return res.status(400).json({ error: 'Invalid id' })
+  }
+  const convo = readConversation(id)
+  if (!convo) {
+    return res.status(404).json({ error: 'Not found' })
+  }
+  res.status(200).json({ id, ...convo })
+}

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
 
 export default function LogsPage() {
+  const router = useRouter()
   const [logs, setLogs] = useState<any[]>([])
-  const [conversations, setConversations] = useState<Record<string, any[]>>({})
+  const [conversations, setConversations] = useState<Record<string, { timestamp: number; messages: any[] }>>({})
 
   useEffect(() => {
     fetch('/api/logs')
@@ -29,10 +31,21 @@ export default function LogsPage() {
       </ul>
       <h2 className="text-xl font-bold mt-8 mb-4">Saved Conversations</h2>
       <ul className="space-y-4">
-        {Object.entries(conversations).map(([id, messages]) => (
-          <li key={id} className="p-2 border rounded">
-            <div className="font-semibold mb-2">Conversation {id}</div>
-            {messages.map((msg: any, mIdx: number) => (
+        {Object.entries(conversations).map(([id, convo]) => (
+          <li key={id} className="p-2 border rounded space-y-2">
+            <div className="flex justify-between items-center gap-2">
+              <div className="font-semibold">Conversation {id}</div>
+              <div className="text-sm text-gray-500">
+                {new Date(convo.timestamp).toLocaleString()}
+              </div>
+              <button
+                className="bg-blue-500 text-white px-2 py-1 rounded"
+                onClick={() => router.push(`/?conversationId=${id}`)}
+              >
+                Continue
+              </button>
+            </div>
+            {convo.messages.map((msg: any, mIdx: number) => (
               <div key={mIdx} className="whitespace-pre-wrap">
                 <span className="font-medium">{msg.role}:</span> {msg.content}
               </div>


### PR DESCRIPTION
## Summary
- store conversations with timestamps
- add API and UI to resume saved conversations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb3084ed4833194e399c6589e9667