### PR TITLE
feat: save conversations and sort by date

### DIFF
--- a/src/lib/logConversation.ts
+++ b/src/lib/logConversation.ts
@@ -68,7 +68,7 @@ export function readConversation(
 
 export function readConversations(): Record<string, StoredConversation> {
   ensureDir()
-  const result: Record<string, StoredConversation> = {}
+  const entries: [string, StoredConversation][] = []
   for (const file of fs.readdirSync(conversationsDir)) {
     if (!file.endsWith('.json')) continue
     const id = path.basename(file, '.json')
@@ -76,15 +76,16 @@ export function readConversations(): Record<string, StoredConversation> {
       const data = fs.readFileSync(path.join(conversationsDir, file), 'utf8')
       const parsed = JSON.parse(data)
       if (Array.isArray(parsed)) {
-        result[id] = { timestamp: 0, messages: parsed }
+        entries.push([id, { timestamp: 0, messages: parsed }])
       } else {
-        result[id] = parsed
+        entries.push([id, parsed])
       }
     } catch {
-      result[id] = { timestamp: 0, messages: [] }
+      entries.push([id, { timestamp: 0, messages: [] }])
     }
   }
-  return result
+  entries.sort((a, b) => b[1].timestamp - a[1].timestamp)
+  return Object.fromEntries(entries)
 }
 
 export function appendConversation(entry: ConversationEntry) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -143,8 +143,15 @@ export default function HomePage() {
       await fetch('/api/log', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ conversationId, messages, force: true }),
+        body: JSON.stringify({ conversationId, messages }),
       })
+      const newId = uuidv4()
+      setMessages([])
+      setConversationId(newId)
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem('chat')
+        sessionStorage.setItem('conversationId', newId)
+      }
     } catch {
       // ignore
     }

--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -31,27 +31,29 @@ export default function LogsPage() {
       </ul>
       <h2 className="text-xl font-bold mt-8 mb-4">Saved Conversations</h2>
       <ul className="space-y-4">
-        {Object.entries(conversations).map(([id, convo]) => (
-          <li key={id} className="p-2 border rounded space-y-2">
-            <div className="flex justify-between items-center gap-2">
-              <div className="font-semibold">Conversation {id}</div>
-              <div className="text-sm text-gray-500">
-                {new Date(convo.timestamp).toLocaleString()}
+        {Object.entries(conversations)
+          .sort((a, b) => b[1].timestamp - a[1].timestamp)
+          .map(([id, convo]) => (
+            <li key={id} className="p-2 border rounded space-y-2">
+              <div className="flex justify-between items-center gap-2">
+                <div className="font-semibold">Conversation {id}</div>
+                <div className="text-sm text-gray-500">
+                  {new Date(convo.timestamp).toLocaleString()}
+                </div>
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => router.push(`/?conversationId=${id}`)}
+                >
+                  Continue
+                </button>
               </div>
-              <button
-                className="bg-blue-500 text-white px-2 py-1 rounded"
-                onClick={() => router.push(`/?conversationId=${id}`)}
-              >
-                Continue
-              </button>
-            </div>
-            {convo.messages.map((msg: any, mIdx: number) => (
-              <div key={mIdx} className="whitespace-pre-wrap">
-                <span className="font-medium">{msg.role}:</span> {msg.content}
-              </div>
-            ))}
-          </li>
-        ))}
+              {convo.messages.map((msg: any, mIdx: number) => (
+                <div key={mIdx} className="whitespace-pre-wrap">
+                  <span className="font-medium">{msg.role}:</span> {msg.content}
+                </div>
+              ))}
+            </li>
+          ))}
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- reset chat after saving conversation to ensure unique IDs
- sort saved conversations by timestamp so newest appear first

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689122adb3c883319352910381660b61