### PR TITLE
feat: save conversations and sort by date

### DIFF
--- a/src/pages/logs.tsx
+++ b/src/pages/logs.tsx
@@ -31,27 +31,29 @@ export default function LogsPage() {
       </ul>
       <h2 className="text-xl font-bold mt-8 mb-4">Saved Conversations</h2>
       <ul className="space-y-4">
-        {Object.entries(conversations).map(([id, convo]) => (
-          <li key={id} className="p-2 border rounded space-y-2">
-            <div className="flex justify-between items-center gap-2">
-              <div className="font-semibold">Conversation {id}</div>
-              <div className="text-sm text-gray-500">
-                {new Date(convo.timestamp).toLocaleString()}
+        {Object.entries(conversations)
+          .sort((a, b) => b[1].timestamp - a[1].timestamp)
+          .map(([id, convo]) => (
+            <li key={id} className="p-2 border rounded space-y-2">
+              <div className="flex justify-between items-center gap-2">
+                <div className="font-semibold">Conversation {id}</div>
+                <div className="text-sm text-gray-500">
+                  {new Date(convo.timestamp).toLocaleString()}
+                </div>
+                <button
+                  className="bg-blue-500 text-white px-2 py-1 rounded"
+                  onClick={() => router.push(`/?conversationId=${id}`)}
+                >
+                  Continue
+                </button>
               </div>
-              <button
-                className="bg-blue-500 text-white px-2 py-1 rounded"
-                onClick={() => router.push(`/?conversationId=${id}`)}
-              >
-                Continue
-              </button>
-            </div>
-            {convo.messages.map((msg: any, mIdx: number) => (
-              <div key={mIdx} className="whitespace-pre-wrap">
-                <span className="font-medium">{msg.role}:</span> {msg.content}
-              </div>
-            ))}
-          </li>
-        ))}
+              {convo.messages.map((msg: any, mIdx: number) => (
+                <div key={mIdx} className="whitespace-pre-wrap">
+                  <span className="font-medium">{msg.role}:</span> {msg.content}
+                </div>
+              ))}
+            </li>
+          ))}
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- persist and extend existing conversations without generating new IDs
- show a temporary "Thinking..." message while waiting for the agent
- keep conversation ID when saving so chats can continue seamlessly

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689122adb3c883319352910381660b61