### PR TITLE
feat: store conversations in mongodb

### DIFF
--- a/models/ConversationLog.js
+++ b/models/ConversationLog.js
@@ -1,0 +1,16 @@
+const { Schema, model, models } = require('mongoose');
+
+const messageSchema = new Schema({
+  role: { type: String, enum: ['user', 'agent'], required: true },
+  agentId: { type: String },
+  content: { type: String, required: true },
+  timestamp: { type: Number, required: true }
+});
+
+const conversationSchema = new Schema({
+  conversationId: { type: String, required: true, unique: true },
+  timestamp: { type: Number, required: true },
+  messages: [messageSchema]
+});
+
+module.exports = models.ConversationLog || model('ConversationLog', conversationSchema, 'conversations');

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ app.use(express.json());
 
 mongoose
   .connect(process.env.MONGO_URI, {
+    dbName: 'GWG',
     useNewUrlParser: true,
     useUnifiedTopology: true,
   })

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,0 +1,27 @@
+import mongoose from 'mongoose';
+
+const MONGO_URI = process.env.MONGO_URI as string;
+
+if (!MONGO_URI) {
+  throw new Error('MONGO_URI environment variable is not defined');
+}
+
+interface MongooseGlobal {
+  conn: typeof mongoose | null;
+  promise: Promise<typeof mongoose> | null;
+}
+
+let cached = (global as any).mongoose as MongooseGlobal;
+
+if (!cached) {
+  cached = (global as any).mongoose = { conn: null, promise: null };
+}
+
+export default async function dbConnect() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(MONGO_URI, { dbName: 'GWG' }).then((m) => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/src/pages/api/log.ts
+++ b/src/pages/api/log.ts
@@ -1,7 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { logConversation, Message } from '@/lib/logConversation'
+import dbConnect from '@/lib/mongodb'
+// @ts-ignore - using CommonJS model
+import ConversationLog from '../../../models/ConversationLog'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') return res.status(405).end()
 
   try {
@@ -10,6 +13,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       return res.status(400).json({ error: 'Invalid payload' })
     }
     logConversation(conversationId, messages as Message[], force)
+
+    await dbConnect()
+    await ConversationLog.updateOne(
+      { conversationId },
+      { $set: { timestamp: Date.now(), messages } },
+      { upsert: true }
+    )
+
     res.status(200).json({ ok: true })
   } catch (err: any) {
     res.status(500).json({ error: err.message })


### PR DESCRIPTION
## Summary
- add reusable MongoDB connector
- persist conversation logs to MongoDB
- target GWG database in server connection

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `MONGO_URI="mongodb+srv://orirot13:o1r2i3R4@cluster0.fishcvg.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0" node -e "const mongoose=require('mongoose');mongoose.connect(process.env.MONGO_URI,{dbName:'GWG'}).then(()=>{console.log('connected');return mongoose.connection.close();}).catch(err=>{console.error('connect error',err);});"`

------
https://chatgpt.com/codex/tasks/task_e_689474095d80833182e6ef611dd8a75c