### PR TITLE
feat: load conversations from mongodb

### DIFF
--- a/src/pages/api/logs.ts
+++ b/src/pages/api/logs.ts
@@ -1,11 +1,38 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
+import dbConnect from '@/lib/mongodb'
+// @ts-ignore - using CommonJS model outside of src
+import Conversation from '../../../models/Conversation'
 
-import { readConversations, readLegacyConversations } from '@/lib/logConversation'
+type ConversationMap = Record<
+  string,
+  { timestamp: number; messages: { role: 'user'; content: string }[] }
+>
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   if (req.method !== 'GET') return res.status(405).end()
-  const logs = readLegacyConversations()
-  const conversations = readConversations()
 
-  res.status(200).json({ logs, conversations })
+  try {
+    await dbConnect()
+
+    const docs = await Conversation.find({}).lean()
+
+    const conversations: ConversationMap = {}
+    for (const doc of docs) {
+      const id = doc._id.toString()
+      conversations[id] = {
+        timestamp: new Date(doc.createdAt).getTime(),
+        messages: [{ role: 'user', content: doc.content }],
+      }
+    }
+
+    res.status(200).json({ logs: [], conversations })
+  } catch (err: any) {
+    res
+      .status(500)
+      .json({ error: 'Failed to fetch conversations', details: err.message })
+  }
 }
+


### PR DESCRIPTION
## Summary
- connect `/api/logs` to MongoDB and load conversation documents
- shape conversations into `{ id: { timestamp, messages } }` format

## Testing
- `npm test` *(fails: Missing script: "test")*
- `MONGO_URI="mongodb://localhost:27017/test" npm run lint`
- `MONGO_URI="mongodb://localhost:27017/test" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894a7ad32548331a55d606e8e6506fc