### PR TITLE
Use MongoDB for logs API

### DIFF
--- a/src/pages/api/logs.ts
+++ b/src/pages/api/logs.ts
@@ -1,11 +1,41 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { readConversations, readLegacyConversations } from '@/lib/logConversation'
+import dbConnect from '@/lib/mongodb'
+// @ts-ignore - using CommonJS model
+import Conversation from '../../../models/Conversation'
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') return res.status(405).end()
-  const logs = readLegacyConversations()
-  const conversations = readConversations()
+  try {
+    await dbConnect()
+    const docs = await Conversation.find().lean()
+    const conversations = docs.reduce(
+      (
+        acc: Record<
+          string,
+          { timestamp: number; messages: { role: string; content: string }[] }
+        >,
+        doc: any
+      ) => {
+        acc[doc._id.toString()] = {
+          timestamp: new Date(doc.createdAt).getTime(),
+          messages: [
+            {
+              role: 'user',
+              content: doc.content,
+            },
+          ],
+        }
+        return acc
+      },
+      {} as Record<
+        string,
+        { timestamp: number; messages: { role: string; content: string }[] }
+      >
+    )
 
-  res.status(200).json({ logs, conversations })
+    res.status(200).json({ logs: [], conversations })
+  } catch (err: any) {
+    res.status(500).json({ error: err.message })
+  }
 }


### PR DESCRIPTION
## Summary
- Replace filesystem-based logs API with MongoDB implementation.
- Connect to Atlas via MONGO_URI and fetch all conversation documents.
- Transform MongoDB results into conversation map format and return.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c1048a948331866b97825d83c9e7